### PR TITLE
Fix SIP socket_connect() failure debug message

### DIFF
--- a/includes/sip2.php
+++ b/includes/sip2.php
@@ -704,7 +704,7 @@ class sip2 {
 
         /* open a connection to the host */
         $result = socket_connect($this->socket, $address, $this->port);
-        if (!$oresult) {
+        if (!$result) {
             $this->_debugmsg("SIP2: socket_connect() failed. Reason: (". socket_last_error($this->socket). ") " . socket_strerror(socket_last_error($this->socket)));
         } else {
             $this->_debugmsg( "SIP2: --- SOCKET READY ---" );

--- a/includes/sip2.php
+++ b/includes/sip2.php
@@ -705,7 +705,7 @@ class sip2 {
         /* open a connection to the host */
         $result = socket_connect($this->socket, $address, $this->port);
         if (!$oresult) {
-					  $this->_debugmsg("SIP2: socket_connect() failed. Reason: (". socket_last_error($this->socket). ") " . socket_strerror(socket_last_error($this->socket)));
+            $this->_debugmsg("SIP2: socket_connect() failed. Reason: (". socket_last_error($this->socket). ") " . socket_strerror(socket_last_error($this->socket)));
         } else {
             $this->_debugmsg( "SIP2: --- SOCKET READY ---" );
         }

--- a/includes/sip2.php
+++ b/includes/sip2.php
@@ -700,12 +700,12 @@ class sip2 {
         } else {
             $this->_debugmsg( "SIP2: Socket Created" );
         }
-        $this->_debugmsg( "SIP2: Attempting to connect to '$address' on port '{$this->port}'...");
+        $this->_debugmsg( "SIP2: Attempting to connect to '$this->hostname' ($address) on port '{$this->port}'...");
 
         /* open a connection to the host */
         $result = socket_connect($this->socket, $address, $this->port);
-        if (!$result) {
-            $this->_debugmsg("SIP2: socket_connect() failed.\nReason: ($result) " . socket_strerror($result));
+        if (!$oresult) {
+					  $this->_debugmsg("SIP2: socket_connect() failed. Reason: (". socket_last_error($this->socket). ") " . socket_strerror(socket_last_error($this->socket)));
         } else {
             $this->_debugmsg( "SIP2: --- SOCKET READY ---" );
         }

--- a/index.php
+++ b/index.php
@@ -1,4 +1,5 @@
 <?php
+
 session_start();
 include_once('config.php');
 include_once('includes/sip2.php');
@@ -8,22 +9,23 @@ if (isset($_SERVER['QUERY_STRING'])) {
   $formaction .= "?" . htmlentities($_SERVER['QUERY_STRING']);
 }
 
-$page='home';
-//set page for inclusion below
-if (!empty($_GET['page']) && file_exists('pages/'.$_GET['page'].'.php')){
-	$page=$_GET['page'];
-	$include='pages/'.$page.'.php';
-//if there's no page listed go to the home page
-} else {
-	header('location:index.php?page='.$page);
-}
+
+
+// Get page to be included below
+if (!empty($_GET['page']) && file_exists('pages/'.$_GET['page'].'.php'))
+  $page=$_GET['page'];
+else
+  // ...if no page was requested assume 'home'
+  $page='home';
+
+
 
 //header
 include_once('includes/header.php');
 
 //include page
-include_once($include);
+include_once('pages/'.$page.'.php');
 
 //footer
 include_once('includes/footer.php');
-?>
+


### PR DESCRIPTION
When the socket_connect() function failed, the debug message just output 'success' because it was trying to get the error information from the return code, not the socket. 

I also resolved the issue of an undefined variable being logged every time the index page was loaded without the 'page' value supplied.